### PR TITLE
Publishing an empty grid breaks 'Add Row' functionality

### DIFF
--- a/u7dtg.controller.js
+++ b/u7dtg.controller.js
@@ -219,6 +219,11 @@
 
         $scope.addRow = function () {
             if (maxRows == 0 || $scope.model.value.length < maxRows) {
+				
+				if ($scope.model.value === '') {
+                    $scope.model.value = [];
+                }
+				
                 $scope.model.value.push(angular.copy(rowObject));
                 var newrowIndex = $scope.model.value.length - 1;
                 var newRow = $scope.model.value[newrowIndex];

--- a/u7dtg.controller.js
+++ b/u7dtg.controller.js
@@ -220,7 +220,7 @@
         $scope.addRow = function () {
             if (maxRows == 0 || $scope.model.value.length < maxRows) {
 				
-				if ($scope.model.value === '') {
+                if ($scope.model.value === '') {
                     $scope.model.value = [];
                 }
 				


### PR DESCRIPTION
As titled. If value is empty create an array.
